### PR TITLE
Revert frontend dependency downgrades

### DIFF
--- a/public/package-lock.json
+++ b/public/package-lock.json
@@ -1,87 +1,40 @@
 {
   "name": "horseman-article-parser-ui",
   "version": "0.1.81",
-  "lockfileVersion": 3,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "horseman-article-parser-ui",
-      "version": "0.1.81",
-      "license": "GPL-3.0",
-      "dependencies": {
-        "@fortawesome/fontawesome-free": "^5.15.1",
-        "angular": "^1.6.10",
-        "angular-sanitize": "^1.3.0",
-        "angular-socket-io": "0.7.0",
-        "angular-ui-bootstrap": "2.5.0",
-        "bootstrap": "^5.3.8",
-        "jquery": "^3.5.1"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-free": {
+  "dependencies": {
+    "@fortawesome/fontawesome-free": {
       "version": "5.15.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.1.tgz",
-      "integrity": "sha512-OEdH7SyC1suTdhBGW91/zBfR6qaIhThbcN8PUXtXilY4GYnSBbVqOntdHbC1vXwsDnX0Qix2m2+DSU1J51ybOQ==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=6"
-      }
+      "integrity": "sha512-OEdH7SyC1suTdhBGW91/zBfR6qaIhThbcN8PUXtXilY4GYnSBbVqOntdHbC1vXwsDnX0Qix2m2+DSU1J51ybOQ=="
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
+    "angular": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.2.tgz",
+      "integrity": "sha512-IauMOej2xEe7/7Ennahkbb5qd/HFADiNuLSESz9Q27inmi32zB0lnAsFeLEWcox3Gd1F6YhNd1CP7/9IukJ0Gw=="
     },
-    "node_modules/angular": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.10.tgz",
-      "integrity": "sha512-PCZ5/hVdvPQiYyH0VwsPjrErPHRcITnaXxhksceOXgtJeesKHLA7KDu4X/yvcAi+1zdGgGF+9pDxkJvghXI9Wg==",
-      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
-      "license": "MIT"
+    "angular-sanitize": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.7.9.tgz",
+      "integrity": "sha512-nB/xe7JQWF9nLvhHommAICQ3eWrfRETo0EVGFESi952CDzDa+GAJ/2BFBNw44QqQPxj1Xua/uYKrbLsOGWZdbQ=="
     },
-    "node_modules/angular-sanitize": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.3.0.tgz",
-      "integrity": "sha512-BzA7CPE3wNa4XJAtNfEOOmZ6kUFMTPy6gVvbexPF3cqeNZLFsROGHU8WS5MCb7YGG/ivu8PTe+1DKC2wfZvHgA==",
-      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
-      "license": "MIT"
-    },
-    "node_modules/angular-socket-io": {
+    "angular-socket-io": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/angular-socket-io/-/angular-socket-io-0.7.0.tgz",
       "integrity": "sha1-eKjWCqVxlKAzC8MTfU2hCGmLl88="
     },
-    "node_modules/angular-ui-bootstrap": {
+    "angular-ui-bootstrap": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.0.tgz",
       "integrity": "sha1-L6zvuRU4ZlXcX0QVAlgDJRcjbQE="
     },
-    "node_modules/bootstrap": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
-      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
-      }
+    "bootstrap": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
     },
-    "node_modules/jquery": {
+    "jquery": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="

--- a/public/package.json
+++ b/public/package.json
@@ -7,11 +7,11 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.1",
-    "angular": "^1.6.10",
-    "angular-sanitize": "^1.3.0",
+    "angular": "^1.8.2",
+    "angular-sanitize": "1.7.9",
     "angular-socket-io": "0.7.0",
     "angular-ui-bootstrap": "2.5.0",
-    "bootstrap": "^5.3.8",
+    "bootstrap": "^3.4.1",
     "jquery": "^3.5.1"
   }
 }


### PR DESCRIPTION
## Summary
- restore Angular, angular-sanitize, and Bootstrap versions in `public` to their pre-downgrade levels
- return `public/package-lock.json` to lockfile v1 matching restored dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b86ce65c5883328d8582398a1174db